### PR TITLE
Change SSH command to invoke '/bin/bash' on connection

### DIFF
--- a/launcher/et
+++ b/launcher/et
@@ -110,7 +110,7 @@ printf \"PASSWORD:\"
 cat \"\${TMPFILE}\"
 printf \"\\n\"
 "
-(printf "%s\n" "$SSH_PASSWORD_COMMAND" | ssh -T $SSH_COMMAND | grep PASSWORD: | cut -d: -f2) > ${TMPFILE}
+(printf "%s\n" "$SSH_PASSWORD_COMMAND" | ssh -T $SSH_COMMAND '/bin/bash' | grep PASSWORD: | cut -d: -f2) > ${TMPFILE}
 printf '\n' >> ${TMPFILE}
 
 $CLIENT_BINARY --passkeyfile="$TMPFILE" $VERBOSITY --host="$HOSTNAME" --port="$PORT" --log_dir="$LOG_DIR" 2> /tmp/et_err


### PR DESCRIPTION
This allows et to connect to execute the password command on servers that do not have a BASH compatible shell as the default.

I don't feel like this is the *best* approach to this problem. However, it does work for me.  With a remote shell of `/usr/local/bin/fish`, the password command now succeeds.

It's possible that this will cause problems with the `--ssh=` parameter if the user adds a command rather than just flags.