### PR TITLE
Make compliation on FreeBSD work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ find_package(Glog REQUIRED)
 find_package(GFlags REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(Sodium REQUIRED)
+IF(LINUX)
 find_package(SELinux)
+ENDIF()
 find_package(UTempter)
 
 IF(SELINUX_FOUND)
@@ -121,21 +123,38 @@ add_executable (
   terminal/UserTerminalHandler.cpp
   terminal/UserTerminalRouter.cpp
   )
-target_link_libraries (
-  etserver
-  LINK_PUBLIC
-  TerminalCommon
-  EternalTCP-static
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${PROTOBUF_LIBRARIES}
-  ${GLOG_LIBRARIES}
-  ${GFLAGS_LIBRARIES}
-  ${sodium_LIBRARY_RELEASE}
-  ${SELINUX_LIBRARIES}
-  ${UTEMPTER_LIBRARIES}
-  resolv
-  util
+IF(!FREEBSD)
+  target_link_libraries (
+    etserver
+    LINK_PUBLIC
+    TerminalCommon
+    EternalTCP-static
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${PROTOBUF_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${sodium_LIBRARY_RELEASE}
+    ${SELINUX_LIBRARIES}
+    ${UTEMPTER_LIBRARIES}
+    resolv
+    util
   )
+ELSE()
+  target_link_libraries (
+    etserver
+    LINK_PUBLIC
+    TerminalCommon
+    EternalTCP-static
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${PROTOBUF_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${sodium_LIBRARY_RELEASE}
+    ${SELINUX_LIBRARIES}
+    ${UTEMPTER_LIBRARIES}
+    util
+  )
+ENDIF()
 
 add_executable (
   et
@@ -144,20 +163,36 @@ add_executable (
   terminal/PortForwardClientListener.cpp
   terminal/SshSetupHandler.cpp
   )
-target_link_libraries (
-  et
-  LINK_PUBLIC
-  TerminalCommon
-  EternalTCP-static
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${PROTOBUF_LIBRARIES}
-  ${GLOG_LIBRARIES}
-  ${GFLAGS_LIBRARIES}
-  ${sodium_LIBRARY_RELEASE}
-  ${UTEMPTER_LIBRARIES}
-  resolv
-  util
+IF(!FREEBSD)
+  target_link_libraries (
+    et
+    LINK_PUBLIC
+    TerminalCommon
+    EternalTCP-static
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${PROTOBUF_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${sodium_LIBRARY_RELEASE}
+    ${UTEMPTER_LIBRARIES}
+    resolv
+    util
   )
+ELSE()
+  target_link_libraries (
+    et
+    LINK_PUBLIC
+    TerminalCommon
+    EternalTCP-static
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${PROTOBUF_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${sodium_LIBRARY_RELEASE}
+    ${UTEMPTER_LIBRARIES}
+    util
+  )
+ENDIF()
 
 
 if(BUILD_TEST) # Build unit tests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ endif()
 #Using FreeBSD?
 if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     set(FREEBSD TRUE)
-    set(BSD TRUE)
 endif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 
 # Add cmake script directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ if(UNIX)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
 endif()
 
+#Using FreeBSD?
+if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    set(FREEBSD TRUE)
+    set(BSD TRUE)
+endif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+
 # Add cmake script directory.
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -53,6 +59,12 @@ PROTOBUF_GENERATE_CPP(
 
   proto/ET.proto
   )
+
+IF(FREEBSD)
+  set(CORE_LIBRARIES util)
+ELSE()
+  set(CORE_LIBRARIES util resolv)
+ENDIF()
 
 include_directories(
   ext
@@ -123,38 +135,21 @@ add_executable (
   terminal/UserTerminalHandler.cpp
   terminal/UserTerminalRouter.cpp
   )
-IF(!FREEBSD)
-  target_link_libraries (
-    etserver
-    LINK_PUBLIC
-    TerminalCommon
-    EternalTCP-static
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${PROTOBUF_LIBRARIES}
-    ${GLOG_LIBRARIES}
-    ${GFLAGS_LIBRARIES}
-    ${sodium_LIBRARY_RELEASE}
-    ${SELINUX_LIBRARIES}
-    ${UTEMPTER_LIBRARIES}
-    resolv
-    util
-  )
-ELSE()
-  target_link_libraries (
-    etserver
-    LINK_PUBLIC
-    TerminalCommon
-    EternalTCP-static
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${PROTOBUF_LIBRARIES}
-    ${GLOG_LIBRARIES}
-    ${GFLAGS_LIBRARIES}
-    ${sodium_LIBRARY_RELEASE}
-    ${SELINUX_LIBRARIES}
-    ${UTEMPTER_LIBRARIES}
-    util
-  )
-ENDIF()
+
+target_link_libraries (
+  etserver
+  LINK_PUBLIC
+  TerminalCommon
+  EternalTCP-static
+  ${CMAKE_THREAD_LIBS_INIT}
+  ${PROTOBUF_LIBRARIES}
+  ${GLOG_LIBRARIES}
+  ${GFLAGS_LIBRARIES}
+  ${sodium_LIBRARY_RELEASE}
+  ${SELINUX_LIBRARIES}
+  ${UTEMPTER_LIBRARIES}
+  ${CORE_LIBRARIES}
+)
 
 add_executable (
   et
@@ -163,37 +158,20 @@ add_executable (
   terminal/PortForwardClientListener.cpp
   terminal/SshSetupHandler.cpp
   )
-IF(!FREEBSD)
-  target_link_libraries (
-    et
-    LINK_PUBLIC
-    TerminalCommon
-    EternalTCP-static
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${PROTOBUF_LIBRARIES}
-    ${GLOG_LIBRARIES}
-    ${GFLAGS_LIBRARIES}
-    ${sodium_LIBRARY_RELEASE}
-    ${UTEMPTER_LIBRARIES}
-    resolv
-    util
-  )
-ELSE()
-  target_link_libraries (
-    et
-    LINK_PUBLIC
-    TerminalCommon
-    EternalTCP-static
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${PROTOBUF_LIBRARIES}
-    ${GLOG_LIBRARIES}
-    ${GFLAGS_LIBRARIES}
-    ${sodium_LIBRARY_RELEASE}
-    ${UTEMPTER_LIBRARIES}
-    util
-  )
-ENDIF()
 
+target_link_libraries (
+    et
+    LINK_PUBLIC
+    TerminalCommon
+    EternalTCP-static
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${PROTOBUF_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${sodium_LIBRARY_RELEASE}
+    ${UTEMPTER_LIBRARIES}
+    ${CORE_LIBRARIES}
+)
 
 if(BUILD_TEST) # Build unit tests.
   message(STATUS "Enabling test for ${PROJECT_NAME}")

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -31,6 +31,7 @@
 #elif __FreeBSD__
 #include <libutil.h>
 #include <sys/ioctl.h>
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <termios.h>
 #else


### PR DESCRIPTION
The changes are really simple:

1. Don't need SELinux on FreeBSD (for obvious reasons), and compilation fails for some reason if find_package is called looking for it. So I added a guard around that.

2. FreeBSD doesn't need, and in fact can't use libresolv, with that functionality in libc. This meant two changes, one of which can **definitely** be done better. The first is to include sys/socket.h in the FreeBSD includes block. The second is to not link in libresolv. My experience which cmake is very limited, but this seemed to work for me.

Clearly the linking changes in `CMakeLists.txt` could be better, so whatever needs to be done for that just let me know.

Lastly, creating a port for this, so et can be available as a package in the standard set on FreeBSD, should be relatively straightforward and I'll gladly do that as well. Seemed better to not have a patch in there, so doing this part first.

EDIT:

Some further information. The changes were to get things to compile on FreeBSD-11-STABLE. And I didn't run the tests, (which link resolv) on FreeBSD, but I can make that change with further advice on the cmake changes.