### PR TITLE
Fix missing line in reading config file; Update Readme; format.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,17 @@ ET uses ssh for handshaking and encryption, so you must be able to ssh into the 
 ET uses TCP, so you need an open port on your server. By default, it uses 2022.
 
 
-Once you have an open port, the syntax is shown below. You can specify a jumphost and the port et is running on jumphost using `--jumphost` and `--jport`. If no `--port/--jport` is given, et will try to connect to default port 2022.
+Once you have an open port, the syntax is similar to ssh. Username is default to the current username starting the et process, use `-u` or `user@` to specify a different if necessary.
 ```
-et --host hostname (etserver running on port 2022)
-et --host hostname --port 8000
-et --host hostname --jumphost jump_hostname (etserver running on port 2022 on both hostname and jumphost)
-et --host hostname --port 8888 --jumphost jump_hostname --jport 9999
+et hostname (etserver running on default port 2022, username is the same as current)
+et user@hostname:8000 (etserver running on port 8000, different user)
 ```
-Additional arguments that et accept are port forwarding pairs with option `--t="18000:8000, 18001-18003:8001-8003"`, a command to run immediately after the connection is setup through `--c`. Username is default to the current username starting the et process, use `--user` to specify a different if necessary.
+You can specify a jumphost and the port et is running on jumphost using `-jumphost` and `-jport`. If no `-jport` is given, et will try to connect to default port 2022.
+```
+et hostname -jumphost jump_hostname (etserver running on port 2022 on both hostname and jumphost)
+et hostname:8888 -jumphost jump_hostname -jport 9999
+```
+Additional arguments that et accept are port forwarding pairs with option `-t="18000:8000, 18001-18003:8001-8003"`, a command to run immediately after the connection is setup through `-c`.
 
 Starting from the latest release, et supports parsing both user-specific and system-wide ssh config file.
 The config file is required when your sshd on server/jumphost is listening on a port which is not 22.
@@ -98,8 +101,8 @@ Host dev
 With the ssh config file set as above, you can simply call et with
 
 ```
-et --host dev (etserver running on port 2022 on both hostname and jumphost)
-et --host dev --port 8000 --jport 9000 (etserver not running on default port)
+et dev (etserver running on port 2022 on both hostname and jumphost)
+et dev:8000 -jport 9000 (etserver running on port 9000 on jumphost)
 ```
 
 ## Building from source

--- a/terminal/SshSetupHandler.cpp
+++ b/terminal/SshSetupHandler.cpp
@@ -79,11 +79,11 @@ string SshSetupHandler::SetupSsh(string user, string host, int port,
     wait(NULL);
     int nbytes = read(link_client[0], buf_client, sizeof(buf_client));
     try {
-      if (nbytes <= 0 ||
-          split(string(buf_client), ':').size() != 2 ||
+      if (nbytes <= 0 || split(string(buf_client), ':').size() != 2 ||
           split(string(buf_client), ':')[0] != "IDPASSKEY") {
         cout << "Error:  The Eternal Terminal daemon is not running.  "
-            "Please (re)start the et daemon on the server." << endl;
+                "Please (re)start the et daemon on the server."
+             << endl;
         exit(1);
       }
       auto idpasskey = split(string(buf_client), ':')[1];
@@ -94,10 +94,9 @@ string SshSetupHandler::SetupSsh(string user, string host, int port,
       if (returned_id == id && returned_passkey == passkey) {
         LOG(INFO) << "etserver started" << endl;
       } else {
-        LOG(FATAL) << "client/server idpasskey doesn't match: "
-                   << id << " != " << returned_id << " or "
-                   << passkey << " != " << returned_passkey
-                   << endl;
+        LOG(FATAL) << "client/server idpasskey doesn't match: " << id
+                   << " != " << returned_id << " or " << passkey
+                   << " != " << returned_passkey << endl;
       }
     } catch (const runtime_error &err) {
       cout << "Error initializing connection" << err.what() << endl;

--- a/terminal/TerminalClient.cpp
+++ b/terminal/TerminalClient.cpp
@@ -31,7 +31,7 @@ shared_ptr<ClientConnection> globalClient;
 
 termios terminal_backup;
 
-DEFINE_string(user, "", "username to login");
+DEFINE_string(u, "", "username to login");
 DEFINE_string(host, "localhost", "host to join");
 DEFINE_int32(port, 2022, "port to connect on");
 DEFINE_string(c, "", "Command to run immediately after connecting");
@@ -119,14 +119,18 @@ int main(int argc, char** argv) {
     string s(argv[i]);
     if (s == "-h" || s == "--help") {
       cout << "et (options) [user@]hostname[:port]\n"
-"Options:\n"
-"-h Basic usage\n"
-"-p Port for etserver to run on.  Default: 2022\n"
-"-u Username to connect to ssh & ET\n"
-"-v=9 verbose log files\n"
-"-c Initial command to execute upon connecting\n"
-"-t Map local to remote TCP port (TCP Tunneling)\n"
-"   example: et -t=\"18000:8000\" hostname maps localhost:18000 to hostname:8000" << endl;
+              "Options:\n"
+              "-h Basic usage\n"
+              "-p Port for etserver to run on.  Default: 2022\n"
+              "-u Username to connect to ssh & ET\n"
+              "-v=9 verbose log files\n"
+              "-c Initial command to execute upon connecting\n"
+              "-t Map local to remote TCP port (TCP Tunneling)\n"
+              "   example: et -t=\"18000:8000\" hostname maps localhost:18000 "
+              "to hostname:8000\n"
+              "-jumphost Jumphost between localhost and destination\n"
+              "-jport Port to connect on jumphost"
+           << endl;
       exit(1);
     }
   }
@@ -140,11 +144,11 @@ int main(int argc, char** argv) {
   srand(1);
 
   // Parse command-line argument
-  if (argc>1) {
+  if (argc > 1) {
     string arg = string(argv[1]);
     if (arg.find('@') != string::npos) {
       int i = arg.find('@');
-      FLAGS_user = arg.substr(0, i);
+      FLAGS_u = arg.substr(0, i);
       arg = arg.substr(i + 1);
     }
     if (arg.find(':') != string::npos) {
@@ -196,7 +200,7 @@ int main(int argc, char** argv) {
   }
 
   string idpasskeypair = SshSetupHandler::SetupSsh(
-      FLAGS_user, FLAGS_host, FLAGS_port, FLAGS_jumphost, FLAGS_jport);
+      FLAGS_u, FLAGS_host, FLAGS_port, FLAGS_jumphost, FLAGS_jport);
 
   // redirect stderr to file
   stderr = fopen("/tmp/etclient_err", "w+");


### PR DESCRIPTION
1. Fix missing newline in reading config file, which randomly cause corrupted hostname
2. Update -h info, rename flag user to u for short.
3. Update README back to the usage similar to ssh.
4. run format.sh