### PR TITLE
Fix jump connection

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -10,7 +10,8 @@ Connection::~Connection() {
     LOG(ERROR) << "Call shutdown before destructing a Connection.";
   }
   if (socketFd != -1) {
-    closeSocket();
+    LOG(INFO) << "Connection destroyed";
+    Connection::closeSocket();
   }
 }
 
@@ -160,6 +161,6 @@ bool Connection::recover(int newSocketFd) {
 void Connection::shutdown() {
   LOG(INFO) << "Shutting down connection";
   shuttingDown = true;
-  closeSocket();
+  Connection::closeSocket();
 }
 }  // namespace et


### PR DESCRIPTION
* Explicitly use Connection::closeSocket() to differentiate with the one in ClientConnection (which also contains reconnect)
* If jump client is idle, kill the jump->dst connection and restore when the src is back.
* Added some log to LOG(ERROR) due to the current log library issue. 