### PR TITLE
Fix log issues

### DIFF
--- a/etc/et.cfg
+++ b/etc/et.cfg
@@ -6,3 +6,4 @@ port = 2022
 
 [Debug]
 verbose = 0
+silent = 0

--- a/etc/et.cfg
+++ b/etc/et.cfg
@@ -3,3 +3,6 @@
 
 [Networking]
 port = 2022
+
+[Debug]
+verbose = 0

--- a/proto/ETerminal.proto
+++ b/proto/ETerminal.proto
@@ -46,4 +46,5 @@ message InitialPayload {
 
 message ConfigParams {
   optional int32 vlevel = 1;
+  optional int32 minloglevel = 2;
 }

--- a/proto/ETerminal.proto
+++ b/proto/ETerminal.proto
@@ -43,3 +43,7 @@ message PortForwardData {
 message InitialPayload {
   optional bool jumphost = 1 [default = false];
 }
+
+message ConfigParams {
+  optional int32 vlevel = 1;
+}

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -86,6 +86,8 @@ string getIdpasskey() {
 
 void setGlogVerboseLevel(int vlevel) { FLAGS_v = vlevel; }
 
+void setGlogMinLogLevel(int level) { FLAGS_minloglevel = level; }
+
 void setGlogFile(string filename) {
   google::SetLogDestination(google::INFO, (filename + ".INFO.").c_str());
   google::SetLogDestination(google::WARNING, (filename + ".WARNING.").c_str());
@@ -484,6 +486,7 @@ void startJumpHostClient() {
   RawSocketUtils::writeMessage(routerFd, idpasskey);
   ConfigParams config = RawSocketUtils::readProto<ConfigParams>(routerFd);
   setGlogVerboseLevel(config.vlevel());
+  setGlogMinLogLevel(config.minloglevel());
 
   InitialPayload payload;
 
@@ -592,6 +595,12 @@ int main(int argc, char **argv) {
       const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
       if (vlevel) {
         setGlogVerboseLevel(atoi(vlevel));
+      }
+      // read silent setting
+      const char *silent = ini.GetValue("Debug", "silent", NULL);
+      if (silent && atoi(silent) != 0) {
+        setGlogVerboseLevel(0);
+        setGlogMinLogLevel(2);
       }
     } else {
       LOG(FATAL) << "Invalid config file: " << FLAGS_cfgfile;

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -84,6 +84,8 @@ string getIdpasskey() {
   return idpasskey;
 }
 
+void setGlogVerboseLevel(int vlevel) { FLAGS_v = vlevel; }
+
 void setGlogFile(string filename) {
   google::SetLogDestination(google::INFO, (filename + ".INFO.").c_str());
   google::SetLogDestination(google::WARNING, (filename + ".WARNING.").c_str());
@@ -480,6 +482,9 @@ void startJumpHostClient() {
   }
 
   RawSocketUtils::writeMessage(routerFd, idpasskey);
+  ConfigParams config = RawSocketUtils::readProto<ConfigParams>(routerFd);
+  setGlogVerboseLevel(config.vlevel());
+
   InitialPayload payload;
 
   shared_ptr<SocketHandler> jumpclientSocket(new UnixSocketHandler());
@@ -586,7 +591,7 @@ int main(int argc, char **argv) {
       // read verbose level
       const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
       if (vlevel) {
-        FLAGS_v = atoi(vlevel);
+        setGlogVerboseLevel(atoi(vlevel));
       }
     } else {
       LOG(FATAL) << "Invalid config file: " << FLAGS_cfgfile;

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -593,6 +593,11 @@ int main(int argc, char **argv) {
           FLAGS_port = stoi(portString);
         }
       }
+      // read verbose level
+      const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
+      if (vlevel) {
+        FLAGS_v = atoi(vlevel);
+      }
     } else {
       LOG(FATAL) << "Invalid config file: " << FLAGS_cfgfile;
     }

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -426,6 +426,9 @@ void startUserTerminal() {
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);  // set to line buffering
   stderr = fopen(std_file.c_str(), "w+");
   setvbuf(stderr, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+  google::SetLogDestination(google::INFO, (std_file + ".INFO.").c_str());
+  google::SetLogDestination(google::WARNING, (std_file + ".WARNING.").c_str());
+  google::SetLogDestination(google::ERROR, (std_file + ".ERROR.").c_str());
   uth.run();
 }
 
@@ -459,6 +462,9 @@ void startJumpHostClient() {
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);  // set to line buffering
   stderr = fopen(std_file.c_str(), "w+");
   setvbuf(stderr, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+  google::SetLogDestination(google::INFO, (std_file + ".INFO.").c_str());
+  google::SetLogDestination(google::WARNING, (std_file + ".WARNING.").c_str());
+  google::SetLogDestination(google::ERROR, (std_file + ".ERROR.").c_str());
 
   sockaddr_un remote;
 

--- a/terminal/UserTerminalHandler.cpp
+++ b/terminal/UserTerminalHandler.cpp
@@ -61,9 +61,7 @@ void UserTerminalHandler::connectToRouter(const string &idPasskey) {
     }
     exit(1);
   }
-  FATAL_FAIL(
-      RawSocketUtils::writeAll(routerFd, &(idPasskey[0]), idPasskey.length()));
-  FATAL_FAIL(RawSocketUtils::writeAll(routerFd, "\0", 1));
+  RawSocketUtils::writeMessage(routerFd, idPasskey);
 }
 
 void UserTerminalHandler::run() {

--- a/terminal/UserTerminalHandler.cpp
+++ b/terminal/UserTerminalHandler.cpp
@@ -62,6 +62,8 @@ void UserTerminalHandler::connectToRouter(const string &idPasskey) {
     exit(1);
   }
   RawSocketUtils::writeMessage(routerFd, idPasskey);
+  ConfigParams config = RawSocketUtils::readProto<ConfigParams>(routerFd);
+  FLAGS_v = config.vlevel();
 }
 
 void UserTerminalHandler::run() {

--- a/terminal/UserTerminalHandler.cpp
+++ b/terminal/UserTerminalHandler.cpp
@@ -64,6 +64,7 @@ void UserTerminalHandler::connectToRouter(const string &idPasskey) {
   RawSocketUtils::writeMessage(routerFd, idPasskey);
   ConfigParams config = RawSocketUtils::readProto<ConfigParams>(routerFd);
   FLAGS_v = config.vlevel();
+  FLAGS_minloglevel = config.minloglevel();
 }
 
 void UserTerminalHandler::run() {

--- a/terminal/UserTerminalRouter.cpp
+++ b/terminal/UserTerminalRouter.cpp
@@ -28,6 +28,8 @@
 #include <pty.h>
 #endif
 
+#include "ETerminal.pb.h"
+
 namespace et {
 UserTerminalRouter::UserTerminalRouter() {
   sockaddr_un local;
@@ -86,6 +88,10 @@ void UserTerminalRouter::acceptNewConnection(
     string key = buf.substr(slashIndex + 1);
     idFdMap[id] = terminalFd;
     globalServer->addClientKey(id, key);
+    // send config params to terminal
+    ConfigParams config;
+    config.set_vlevel(FLAGS_v);
+    RawSocketUtils::writeProto(terminalFd, config);
   }
 }
 

--- a/terminal/UserTerminalRouter.cpp
+++ b/terminal/UserTerminalRouter.cpp
@@ -91,6 +91,7 @@ void UserTerminalRouter::acceptNewConnection(
     // send config params to terminal
     ConfigParams config;
     config.set_vlevel(FLAGS_v);
+    config.set_minloglevel(FLAGS_minloglevel);
     RawSocketUtils::writeProto(terminalFd, config);
   }
 }


### PR DESCRIPTION
1. Before this PR all terminal specific logs are aggregated by user, stored in /tmp/etserver.{hostname}.{username}.log.INFO.{time}. We cannot tell the difference between log entries from different terminals of the same user. After the change, these logs are created per terminal session, named as /tmp/etserver_terminal_{ID}.INFO.{time}. This way it's much easier for debugging.
2. Add verbose level in /etc/et.cfg. 
Note that only et daemon started by systemd uses /etc/et.cfg, which means a new terminal/jumphost session will be created without reading this file and their VLOG level are not affected. We can definitely make them also read this section, although sounds a bit tricky. What do you think? @MisterTea  