### PR TITLE
Add FreeBSD #define to turn on getline in stdlib

### DIFF
--- a/src/Headers.hpp
+++ b/src/Headers.hpp
@@ -5,6 +5,9 @@
 #include <errno.h>
 #include <pthread.h> /* POSIX Threads */
 #include <stdint.h>
+#if __FreeBSD__
+#define _WITH_GETLINE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/terminal/ParseConfigFile.hpp
+++ b/terminal/ParseConfigFile.hpp
@@ -18,6 +18,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#if __FreeBSD__
+#define _WITH_GETLINE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Sometime before the last release compilation on FreeBSD was broken. The fix is related to calls to getline. A few options for macros to fix exist according to `man getline` on a FreeBSD-11.1-STABLE machine

- define  `_POSIX_C_SOURCE` to be 200809 or greater
- define `_WITH_GETLINE`, which is the option I chose
- define `_BSD_SOURCE`
- define `_GNU_SOURCE`

The previously mentioned manpage lists the reason as compatibility. It further calls out the last two of those options as GNUisms. `_WITH_GETLINE` seemed like the most descriptive, and less likely to break elsewhere versus `POSIX_C_SOURCE`

FWIW, I'd still like to get ET added to the FreeBSD ports but a release that builds will make that easier so patches don't have to be kept and so on.

[Edited for extra ` placement]