### PR TITLE
Compliation on NetBSD

### DIFF
--- a/src/Headers.hpp
+++ b/src/Headers.hpp
@@ -15,6 +15,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#if __NetBSD__
+#include <util.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <deque>

--- a/src/UnixSocketHandler.cpp
+++ b/src/UnixSocketHandler.cpp
@@ -72,7 +72,11 @@ int UnixSocketHandler::connect(const std::string &hostname, int port) {
   memset(&hints, 0, sizeof(addrinfo));
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
+#if __NetBSD__
+  hints.ai_flags = (AI_CANONNAME | AI_ADDRCONFIG);
+#else
   hints.ai_flags = (AI_CANONNAME | AI_V4MAPPED | AI_ADDRCONFIG | AI_ALL);
+#endif
   std::string portname = std::to_string(port);
 
   // (re)initialize the DNS system

--- a/terminal/TerminalClient.cpp
+++ b/terminal/TerminalClient.cpp
@@ -206,9 +206,14 @@ int main(int argc, char** argv) {
   string idpasskeypair = SshSetupHandler::SetupSsh(
       FLAGS_u, FLAGS_host, host_alias, FLAGS_port, FLAGS_jumphost, FLAGS_jport);
 
+#if __NetBSD__
+  FILE* stderr_stream = freopen("/tmp/etclient_err", "w+", stderr);
+  setvbuf(stderr_stream, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+#else
   // redirect stderr to file
   stderr = fopen("/tmp/etclient_err", "w+");
   setvbuf(stderr, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+#endif
 
   if (!FLAGS_jumphost.empty()) {
     FLAGS_host = FLAGS_jumphost;

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -31,10 +31,8 @@
 #include <util.h>
 #elif __FreeBSD__
 #include <libutil.h>
-#include <sys/ioctl.h>
 #include <sys/socket.h>
-#include <sys/types.h>
-#include <termios.h>
+#elif __NetBSD__ // do not need pty.h on NetBSD
 #else
 #include <pty.h>
 #include <signal.h>
@@ -99,10 +97,17 @@ void setDaemonLogFile(string idpasskey, string daemonType) {
   string first_idpass_chars = idpasskey.substr(0, 10);
   string std_file =
       string("/tmp/etserver_") + daemonType + "_" + first_idpass_chars;
+#if __NetBSD__
+    FILE* stdout_stream = freopen("/tmp/etclient_err", "w+", stdout);
+    setvbuf(stdout_stream, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+    FILE* stderr_stream = freopen("/tmp/etclient_err", "w+", stderr);
+    setvbuf(stderr_stream, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+#else
   stdout = fopen(std_file.c_str(), "w+");
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);  // set to line buffering
   stderr = fopen(std_file.c_str(), "w+");
   setvbuf(stderr, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+#endif
   setGlogFile(std_file);
 }
 
@@ -627,10 +632,17 @@ int main(int argc, char **argv) {
     if (::daemon(0, 0) == -1) {
       LOG(FATAL) << "Error creating daemon: " << strerror(errno);
     }
+#if __NetBSD__
+    FILE* stdout_stream = freopen("/tmp/etclient_err", "w+", stdout);
+    setvbuf(stdout_stream, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+    FILE* stderr_stream = freopen("/tmp/etclient_err", "w+", stderr);
+    setvbuf(stderr_stream, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+#else
     stdout = fopen("/tmp/etserver_err", "w+");
     setvbuf(stdout, NULL, _IOLBF, BUFSIZ);  // set to line buffering
     stderr = fopen("/tmp/etserver_err", "w+");
     setvbuf(stderr, NULL, _IOLBF, BUFSIZ);  // set to line buffering
+#endif
   }
 
   startServer();

--- a/terminal/UserTerminalRouter.cpp
+++ b/terminal/UserTerminalRouter.cpp
@@ -21,9 +21,7 @@
 #include <util.h>
 #elif __FreeBSD__
 #include <libutil.h>
-#include <sys/ioctl.h>
-#include <sys/types.h>
-#include <termios.h>
+#elif __NetBSD__ // do not need pty.h on NetBSD
 #else
 #include <pty.h>
 #endif


### PR DESCRIPTION
This adds the necessary `#include`s and `#if`s for getting et up and going on NetBSD.

- NetBSD doesn't have all of the `ai_flags`
- Uses `freopen` and passes `stderr` as an arg, rather than assigning to it.
- Calls `waitpid` instead of `waitid`. NetBSD-7 doesn't have `waitid`. The manpage for NetBSD-CURRENT has `waitid` so presumably the OS specific bit can be removed once NetBSD-8 is released.
- This also removed some `#include`s that were in a conditional branch, but also unconditionally brought it.

In particular, I imagine the way `freopen` is handled is suboptimal. My underdeveloped C++ skillset is showing sadly. But this got everything to work. Any suggestions on improvement are appreciated.