### PR TITLE
Throw error in raw socket read/write

### DIFF
--- a/terminal/RawSocketUtils.cpp
+++ b/terminal/RawSocketUtils.cpp
@@ -11,7 +11,8 @@ int RawSocketUtils::writeAll(int fd, const char* buf, size_t count) {
         usleep(1000 * 100);
         continue;
       }
-      return rc;
+      // return rc;
+      throw std::runtime_error("Cannot write to raw socket");
     }
     if (rc == 0) {
       LOG(ERROR) << "Could not write byte, trying again...";
@@ -31,7 +32,8 @@ int RawSocketUtils::readAll(int fd, char* buf, size_t count) {
         usleep(1000 * 100);
         continue;
       }
-      return rc;
+      // return rc;
+      throw std::runtime_error("Cannot read from raw socket");
     }
     if (rc == 0) {
       throw std::runtime_error("Socket has closed abruptly.");

--- a/terminal/RawSocketUtils.cpp
+++ b/terminal/RawSocketUtils.cpp
@@ -11,7 +11,6 @@ int RawSocketUtils::writeAll(int fd, const char* buf, size_t count) {
         usleep(1000 * 100);
         continue;
       }
-      // return rc;
       throw std::runtime_error("Cannot write to raw socket");
     }
     if (rc == 0) {
@@ -32,7 +31,6 @@ int RawSocketUtils::readAll(int fd, char* buf, size_t count) {
         usleep(1000 * 100);
         continue;
       }
-      // return rc;
       throw std::runtime_error("Cannot read from raw socket");
     }
     if (rc == 0) {

--- a/terminal/RawSocketUtils.hpp
+++ b/terminal/RawSocketUtils.hpp
@@ -12,33 +12,33 @@ class RawSocketUtils {
 
   static inline string readMessage(int fd) {
     int64_t length;
-    FATAL_FAIL(readAll(fd, (char*)&length, sizeof(int64_t)));
+    readAll(fd, (char*)&length, sizeof(int64_t));
     if (length < 0 || length > 128 * 1024 * 1024) {
       // If the message is < 0 or too big, assume this is a bad packet and throw
       throw std::runtime_error("Invalid size (<0 or >128 MB)");
     }
     string s(length, 0);
-    FATAL_FAIL(readAll(fd, &s[0], length));
+    readAll(fd, &s[0], length);
     return s;
   }
 
   static inline void writeMessage(int fd, const string& s) {
     int64_t length = s.length();
-    FATAL_FAIL(writeAll(fd, (const char*)&length, sizeof(int64_t)));
-    FATAL_FAIL(writeAll(fd, &s[0], length));
+    writeAll(fd, (const char*)&length, sizeof(int64_t));
+    writeAll(fd, &s[0], length);
   }
 
   template <typename T>
   static inline T readProto(int fd) {
     T t;
     int64_t length;
-    FATAL_FAIL(readAll(fd, (char*)&length, sizeof(int64_t)));
+    readAll(fd, (char*)&length, sizeof(int64_t));
     if (length < 0 || length > 128 * 1024 * 1024) {
       // If the message is < 0 or too big, assume this is a bad packet and throw
       throw std::runtime_error("Invalid size (<0 or >128 MB)");
     }
     string s(length, 0);
-    FATAL_FAIL(readAll(fd, &s[0], length));
+    readAll(fd, &s[0], length);
     if (!t.ParseFromString(s)) {
       throw std::runtime_error("Invalid proto");
     }
@@ -50,8 +50,8 @@ class RawSocketUtils {
     string s;
     t.SerializeToString(&s);
     int64_t length = s.length();
-    FATAL_FAIL(writeAll(fd, (const char*)&length, sizeof(int64_t)));
-    FATAL_FAIL(writeAll(fd, &s[0], length));
+    writeAll(fd, (const char*)&length, sizeof(int64_t));
+    writeAll(fd, &s[0], length);
   }
 };
 }  // namespace et

--- a/terminal/TerminalClient.cpp
+++ b/terminal/TerminalClient.cpp
@@ -420,8 +420,7 @@ int main(int argc, char** argv) {
               // VLOG(1) << "Got byte: " << int(b) << " " << char(b) << " " <<
               // globalClient->getReader()->getSequenceNumber();
               keepaliveTime = time(NULL) + KEEP_ALIVE_DURATION;
-              FATAL_FAIL(
-                  RawSocketUtils::writeAll(STDOUT_FILENO, &s[0], s.length()));
+              RawSocketUtils::writeAll(STDOUT_FILENO, &s[0], s.length());
               break;
             }
             case et::PacketType::KEEP_ALIVE:

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -140,9 +140,8 @@ void runJumpHost(shared_ptr<ServerClientConnection> serverClientState) {
           string message = RawSocketUtils::readMessage(terminalFd);
           serverClientState->writeMessage(message);
         } catch (const std::runtime_error &ex) {
-          LOG(INFO) << "Terminal session ended";
+          LOG(INFO) << "Terminal session ended" << ex.what();
           run = false;
-          globalServer->removeClient(serverClientState->getId());
           break;
         }
       }
@@ -156,9 +155,10 @@ void runJumpHost(shared_ptr<ServerClientConnection> serverClientState) {
           try {
             RawSocketUtils::writeMessage(terminalFd, message);
           } catch (const std::runtime_error &ex) {
-            LOG(INFO) << "Terminal session ended";
+            LOG(INFO) << "Unix socket died between global daemon and terminal router: "
+		      << ex.what();
             run = false;
-            globalServer->removeClient(serverClientState->getId());
+	    break;
           }
         }
       }

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -530,6 +530,7 @@ void startJumpHostClient() {
     }
   }
   LOG(ERROR) << "Jumpclient shutdown";
+  close(routerFd);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
* throw runtime error in raw socket read/write
* remove LOG(FATAL) for calls to raw socket read/write
* catch runtime error from raw socket read/write and LOG(FATAL) them except for runJumphost and runTerminal.
* close(routerFd) when jump client exit normally
* format code
